### PR TITLE
Feature: [Attribute] disable color by `NO_COLOR` and style by `NO_STYLE`

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Test
-        run: zig build test
+        run: unset NO_COLOR; unset NO_STYLE; zig build test

--- a/src/helper.zig
+++ b/src/helper.zig
@@ -10,10 +10,6 @@ pub const Alias = struct {
 };
 
 const String = Alias.String;
-const LiteralString = Alias.LiteralString;
-const print = Alias.print;
-const sprint = Alias.sprint;
-const FormatOptions = Alias.FormatOptions;
 
 pub const Formatter = struct {
     pub fn anyFormat(v: anytype, writer: anytype) @TypeOf(writer).Error!void {
@@ -30,5 +26,41 @@ pub const Formatter = struct {
     pub fn enumFormat_c(v: anytype, writer: anytype) @TypeOf(writer).Error!void {
         assert(@typeInfo(@TypeOf(v)) == .@"enum");
         return std.fmt.formatIntValue(@intFromEnum(v), "c", .{}, writer);
+    }
+    pub fn RawFormatter(T: type) type {
+        return struct {
+            v: T,
+            pub fn format(self: @This(), comptime fmt: []const u8, options: Alias.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+                try self.v.rawFormat(fmt, options, writer);
+            }
+        };
+    }
+    pub fn rawFormatter(v: anytype) RawFormatter(@TypeOf(v)) {
+        return .{ .v = v };
+    }
+};
+
+pub const Env = struct {
+    pub fn flag(key: String) bool {
+        const GetEnvVarOwnedError = std.process.GetEnvVarOwnedError;
+        var Allocator = std.heap.DebugAllocator(.{}).init;
+        const allocator = Allocator.allocator();
+        const value = std.process.getEnvVarOwned(allocator, key) catch |err| switch (err) {
+            GetEnvVarOwnedError.EnvironmentVariableNotFound => return false,
+            else => unreachable,
+        };
+        defer allocator.free(value);
+        return value.len != 0;
+    }
+    /// cache flag
+    pub fn Flag(key: String) type {
+        return struct {
+            var value: ?bool = null;
+            pub fn check() bool {
+                if (value == null)
+                    value = flag(key);
+                return value.?;
+            }
+        };
     }
 };


### PR DESCRIPTION
- let `Attribute` and `Value` support `NO_COLOR` and `NO_STYLE`
- call `no_color` and `no_style` of attribute to set ability explicitly instead from environment variables
- if need comptime format, call `raw()`
- remove `_keep` field from `Value` and `AttrWriter`