### PR TITLE
Feature: [Attribute] disable color by `NO_COLOR` and style by `NO_STYLE`

### DIFF
--- a/src/attribute.zig
+++ b/src/attribute.zig
@@ -529,7 +529,7 @@ const _test = struct {
     test AttrWriter {
         var buffer = std.mem.zeroes([512]u8);
         var bufferStream = std.io.fixedBufferStream(&buffer);
-        const writer = Preset.trust().apply(bufferStream.writer());
+        const writer = Preset.trust().no_color(false).no_style(false).apply(bufferStream.writer());
         try writer.print("string {s} int {d}", .{ "hello", 6 });
         try testing.expectEqualStrings(
             "\x1b[1;21;32;47mstring hello int 6",

--- a/src/helper.zig
+++ b/src/helper.zig
@@ -10,10 +10,6 @@ pub const Alias = struct {
 };
 
 const String = Alias.String;
-const LiteralString = Alias.LiteralString;
-const print = Alias.print;
-const sprint = Alias.sprint;
-const FormatOptions = Alias.FormatOptions;
 
 pub const Formatter = struct {
     pub fn anyFormat(v: anytype, writer: anytype) @TypeOf(writer).Error!void {
@@ -30,5 +26,41 @@ pub const Formatter = struct {
     pub fn enumFormat_c(v: anytype, writer: anytype) @TypeOf(writer).Error!void {
         assert(@typeInfo(@TypeOf(v)) == .@"enum");
         return std.fmt.formatIntValue(@intFromEnum(v), "c", .{}, writer);
+    }
+    pub fn RawFormatter(T: type) type {
+        return struct {
+            v: T,
+            pub fn format(self: @This(), comptime fmt: []const u8, options: Alias.FormatOptions, writer: anytype) @TypeOf(writer).Error!void {
+                try self.v.rawFormat(fmt, options, writer);
+            }
+        };
+    }
+    pub fn rawFormatter(v: anytype) RawFormatter(@TypeOf(v)) {
+        return .{ .v = v };
+    }
+};
+
+pub const Env = struct {
+    pub fn flag(key: String) bool {
+        const GetEnvVarOwnedError = std.process.GetEnvVarOwnedError;
+        var Allocator = std.heap.DebugAllocator(.{}).init;
+        const allocator = Allocator.allocator();
+        const value = std.process.getEnvVarOwned(allocator, key) catch |err| switch (err) {
+            GetEnvVarOwnedError.EnvironmentVariableNotFound => return false,
+            else => unreachable,
+        };
+        defer allocator.free(value);
+        return value.len != 0;
+    }
+    /// cache flag
+    pub fn Flag(key: String) type {
+        return struct {
+            var value: ?bool = null;
+            pub fn check() bool {
+                if (value == null)
+                    value = flag(key);
+                return value.?;
+            }
+        };
     }
 };


### PR DESCRIPTION
- let `Attribute` and `Value` support `NO_COLOR` and `NO_STYLE`
- call `no_color` and `no_style` of attribute to set ability explicitly instead from environment variables
- if need comptime format, call `raw()`
- remove `_keep` field from `Value` and `AttrWriter`